### PR TITLE
Fixed part 1 for windows.

### DIFF
--- a/src/bin/01.rs
+++ b/src/bin/01.rs
@@ -3,13 +3,11 @@ use std::{collections::HashMap, str};
 advent_of_code::solution!(1);
 
 fn parse_and_unzip(input: &str) -> Option<(Vec<i64>, Vec<i64>)> {
-    const ROW_DELIMITER: &str = "\n";
     const PAIR_DELIMITER: &str = "   ";
 
     Some(
         input
-            .split(ROW_DELIMITER)
-            .take_while(|x| !x.is_empty())
+            .lines()
             .map(|x| {
                 let pair = x.split_once(PAIR_DELIMITER)?;
                 Some((pair.0.parse::<i64>().ok()?, pair.1.parse::<i64>().ok()?))


### PR DESCRIPTION
Turns out on windows we have to be a little more careful when splitting lines. Thankfully there's a std::str function to do this truly difficult work for us.